### PR TITLE
fix: restrict the peer dep version for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "vitest": ">2.1.5"
+    "vitest": ">=2.1.5 <3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "Nazar Hussain",
     "email": "nazarhussain@gmail.com"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
- Restrict the peer dep version for vitest
- Make sure it show proper error with latest version of vitest