### PR TITLE
deps: restrict peer deps for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "vitest": ">=3.0.0"
+    "vitest": ">=3.0.0 <3.1.0"
   }
 }


### PR DESCRIPTION
Restrict the peer deps for vitest as the current version breaks with `> 3.1.0`